### PR TITLE
fix: cleanup of session storage with simpler keys

### DIFF
--- a/frontend/src/pages/bookOverview/BookOverview.js
+++ b/frontend/src/pages/bookOverview/BookOverview.js
@@ -9,10 +9,13 @@ import "./BookOverview.css";
 import bookImages from "../../utils/loadBookImages";
 import { handleAddToCart, handleCheckout, handleAddBookmark, handlePlaceOnHold } from "../../utils/setSessionStorage";
 
-const BookOverview = ({ name, authors, number_of_physical_copies_available, is_ebook_available, published_date, description }) => {
+const BookOverview = () => {
 	const { bookId: id } = useParams();
 	const [bookTypeCheckout, setBookTypeCheckout] = useState("");
 	const [quantity, setQuantity] = useState(0);
+	const books = JSON.parse(sessionStorage.getItem("books")) || {};
+	const book = books[id] || {};
+	const { name, authors, published_date, number_of_physical_copies_available, is_ebook_available, description } = book;
 
 	return (
 		<div>
@@ -72,7 +75,7 @@ const BookOverview = ({ name, authors, number_of_physical_copies_available, is_e
 							}}
 							/>
 							<Button text="Bookmark" borderRadius={"0"} onClick={() => {
-								handleAddBookmark({ id, name, authors, number_of_physical_copies_available, is_ebook_available });
+								handleAddBookmark(id);
 							}}
 							/>
 						</div>
@@ -136,22 +139,22 @@ const BookOverview = ({ name, authors, number_of_physical_copies_available, is_e
 					<div className="book-overview-checkout-cart-book-now-buttons">
 						{(bookTypeCheckout && bookTypeCheckout === "physical" && number_of_physical_copies_available <= 0) || ((bookTypeCheckout === "ebook" || bookTypeCheckout === "audio") && is_ebook_available === false) ? (
 							<Button text={"Place On Hold"} onClick={() => {
-								handlePlaceOnHold({ id, name, authors, bookType: bookTypeCheckout, quantity, number_of_physical_copies_available, is_ebook_available });
+								handlePlaceOnHold({ id, bookTypeCheckout });
 							}} fontSize={"18px"} backgroundColor={"#f4d473"} />) : (
 							<Button text="Add to Cart" onClick={
 								() => {
-									handleAddToCart({ id, name, authors, bookTypeCheckout, quantity, number_of_physical_copies_available, is_ebook_available });
+									handleAddToCart({ id, bookTypeCheckout, quantity });
 								}
 							} fontSize={"18px"} backgroundColor={"green"} disabled={
-								!bookTypeCheckout || (bookTypeCheckout === "physical" && number_of_physical_copies_available <= 0) || (bookTypeCheckout === "ebook" && is_ebook_available === false)
+								!bookTypeCheckout || (bookTypeCheckout === "physical" && number_of_physical_copies_available <= 0) || ((bookTypeCheckout === "ebook" || bookTypeCheckout === "audio") && is_ebook_available === false)
 							} />
 						)}
 						<Button text="Checkout Book Now" onClick={
 							() => {
-								handleCheckout({ id, name, authors, bookTypeCheckout });
+								handleCheckout({ id, bookTypeCheckout, quantity });
 							}
 						} fontSize={"18px"} disabled={
-							!bookTypeCheckout || (bookTypeCheckout === "physical" && number_of_physical_copies_available <= 0) || (bookTypeCheckout === "ebook" && is_ebook_available === false)
+							!bookTypeCheckout || (bookTypeCheckout === "physical" && number_of_physical_copies_available <= 0) || ((bookTypeCheckout === "ebook" || bookTypeCheckout === "audio") && is_ebook_available === false)
 						}
 						/>
 					</div>

--- a/frontend/src/pages/profile/BookShelf.js
+++ b/frontend/src/pages/profile/BookShelf.js
@@ -8,6 +8,18 @@ import { useNavigate } from "react-router-dom";
 const BookShelf = () => {
 	const navigate = useNavigate();
 	const my_library = JSON.parse(sessionStorage.getItem("my_library")) || {};
+	const books = JSON.parse(sessionStorage.getItem("books")) || {};
+	const my_library_book_ids = Object.keys(my_library);
+	const my_library_books = {};
+
+	my_library_book_ids.forEach((id) => {
+		if (books[id]) {
+			my_library_books[id] = {
+				...my_library[id],
+				...books[id],
+			}
+		}
+	});
 
 	return (
 		<div className="profile-page-container">
@@ -17,18 +29,18 @@ const BookShelf = () => {
 					<h1 className="profile-page-header-text">My Library</h1>
 				</div>
 				<div className="profile-page-cards-container">
-					{my_library && Object.keys(my_library).length > 0 ? (
-						Object.keys(my_library).map((id) => (
+					{my_library_books && Object.keys(my_library_books).length > 0 ? (
+						Object.keys(my_library_books).map((id) => (
 							<BookCard
 								key={id}
 								id={id}
-								name={my_library[id].name}
-								authors={my_library[id].authors}
-								first_line={"Checked out: " + my_library[id].checked_out_date}
-								second_line={"Access Until: " + my_library[id].return_date}
+								name={my_library_books[id].name}
+								authors={my_library_books[id].authors}
+								first_line={"Checked out: " + my_library_books[id].checked_out_date}
+								second_line={"Access Until: " + my_library_books[id].return_date}
 								ButtonComponent={() => (
 									<div className="card-button-container">
-										{my_library[id].is_physical === true ? (
+										{my_library_books[id].is_physical === true ? (
 											<p>Physical Copy</p>
 										) : (
 											<Button text={"Read this Book"} borderRadius={"0"} textColor={"white"} backgroundColor={"#434EB4"} onClick={() => navigate("/bookShelf/" + id)} />

--- a/frontend/src/pages/profile/History.js
+++ b/frontend/src/pages/profile/History.js
@@ -8,18 +8,13 @@ import "./profile-all-pages.css";
 
 const History = () => {
 	const [history_books, setHistoryBooks] = useState({});
-	const [bookmarked_books, setBookmarkedBooks] = useState({});
+	const [bookmarked_books, setBookmarkedBooks] = useState([]);
 	const [on_hold_books, setOnHoldBooks] = useState({});
+	const books = JSON.parse(sessionStorage.getItem("books")) || {};
 	const navigate = useNavigate();
 
 	const handleBookmark = (id) => {
-		const res = handleAddBookmark({
-			id: id,
-			name: history_books[id].name,
-			authors: history_books[id].authors,
-			number_of_physical_copies_available: history_books[id].number_of_physical_copies_available,
-			is_ebook_available: history_books[id].is_ebook_available,
-		});
+		const res = handleAddBookmark(id);
 		setBookmarkedBooks(res);
 	};
 
@@ -30,7 +25,7 @@ const History = () => {
 
 	useEffect(() => {
 		const history_books = JSON.parse(sessionStorage.getItem("history")) || {};
-		const bookmarked_books = JSON.parse(sessionStorage.getItem("book_marked")) || {};
+		const bookmarked_books = JSON.parse(sessionStorage.getItem("book_marked")) || [];
 		const on_hold_books = JSON.parse(sessionStorage.getItem("on_hold")) || {};
 
 		setHistoryBooks(history_books);
@@ -51,10 +46,10 @@ const History = () => {
 							<BookCard
 								key={id}
 								id={id}
-								authors={history_books[id].authors}
+								authors={books[id].authors}
 								first_line={`Checked out: ${history_books[id].checked_out_date}`}
 								second_line={`Returned on: ${history_books[id].returned_date}`}
-								name={history_books[id].name}
+								name={books[id].name}
 								ButtonComponent={() => (
 									<div className="card-button-container">
 										{on_hold_books && Object.keys(on_hold_books).length > 0 && Object.keys(on_hold_books).includes(id) ? (
@@ -62,7 +57,7 @@ const History = () => {
 										) : (
 											<Button text={"Add to Cart"} onClick={() => navigate(`/book/${id}`)} textColor={"white"} backgroundColor={"#43B447"} borderRadius={"0px"} padding={"10px 20px"} fontSize={"16px"} />
 										)}
-										{bookmarked_books && Object.keys(bookmarked_books).length > 0 && Object.keys(bookmarked_books).includes(id) ? (
+										{bookmarked_books && bookmarked_books.length > 0 && bookmarked_books.includes(id) ? (
 											<Button text={"Remove Bookmark"} onClick={() => handleRemoveBookmark(id)} textColor={"white"} borderRadius={"0px"} padding={"10px 20px"} fontSize={"16px"} />
 										) : (
 											<Button text={"Bookmark"} onClick={() => handleBookmark(id)} textColor={"white"} borderRadius={"0px"} padding={"10px 20px"} fontSize={"16px"} />

--- a/frontend/src/utils/setSessionStorage.js
+++ b/frontend/src/utils/setSessionStorage.js
@@ -1,77 +1,77 @@
-const handleAddToCart = ({ id, name, authors, bookTypeCheckout, quantity, number_of_physical_copies_available, is_ebook_available }) => {
+const returnDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString();
+
+const handleAddToCart = ({ id, bookTypeCheckout, quantity }) => {
 	const cart = JSON.parse(sessionStorage.getItem("cart")) || {};
+
 	const bookKey = id;
 	if (!cart[bookKey]) {
 		cart[bookKey] = {
-			name: name,
-			authors: authors,
 			is_physical: bookTypeCheckout === "physical",
 			quantity: bookTypeCheckout === "physical" ? parseInt(quantity) : 1,
-			number_of_physical_copies_available: bookTypeCheckout === "physical" ? number_of_physical_copies_available - quantity : number_of_physical_copies_available,
-			is_ebook_available: is_ebook_available,
-			return_date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString(),
+			return_date: returnDate,
 		};
 	} else {
 		if (cart[bookKey].is_physical !== (bookTypeCheckout === "physical")) {
 			cart[bookKey].is_physical = bookTypeCheckout === "physical";
 		}
-		cart[bookKey].quantity = bookTypeCheckout === "physical" ? parseInt(cart[bookKey].quantity) + parseInt(quantity) : 1;
-		cart[bookKey].return_date = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString();
+		cart[bookKey].quantity = bookTypeCheckout === "physical" ? cart[bookKey].quantity + parseInt(quantity) : 1;
+		cart[bookKey].return_date = returnDate;
 	}
 
 	sessionStorage.setItem("cart", JSON.stringify(cart));
 	return cart;
 };
 
-const handleCheckout = ({ id, name, authors, bookTypeCheckout }) => {
+const handleCheckout = ({ id, bookTypeCheckout, quantity }) => {
+	const books = JSON.parse(sessionStorage.getItem("books")) || {};
 	const my_library = JSON.parse(sessionStorage.getItem("my_library")) || {};
 	const bookKey = id;
 
 	if (!my_library[bookKey]) {
 		my_library[bookKey] = {
-			name: name,
-			authors: authors,
 			is_physical: bookTypeCheckout === "physical",
 			checked_out_date: new Date().toLocaleDateString(),
-			return_date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString(),
+			return_date: returnDate,
 		};
 	} else {
 		if (my_library[bookKey].is_physical !== (bookTypeCheckout === "physical")) {
 			my_library[bookKey].is_physical = bookTypeCheckout === "physical";
 		}
 		my_library[bookKey].checked_out_date = new Date().toLocaleDateString();
-		my_library[bookKey].return_date = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString();
+		my_library[bookKey].return_date = returnDate;
 	}
 
+	books[bookKey].number_of_physical_copies_available -= bookTypeCheckout === "physical" ? parseInt(quantity) : 0;
+
 	sessionStorage.setItem("my_library", JSON.stringify(my_library));
+	sessionStorage.setItem("books", JSON.stringify(books));
 	return my_library;
 };
 
-const handleAddBookmark = ({ id, name, authors, number_of_physical_copies_available, is_ebook_available }) => {
-	const bookmarked = JSON.parse(sessionStorage.getItem("book_marked")) || {};
-	bookmarked[id] = {
-		name: name,
-		authors: authors,
-		bookmarked_on: new Date().toLocaleDateString(),
-		number_of_physical_copies_available: number_of_physical_copies_available,
-		is_ebook_available: is_ebook_available,
+const handleAddBookmark = (id) => {
+	const bookmarked = JSON.parse(sessionStorage.getItem("book_marked")) || [];
+
+	if (!bookmarked.includes(id)) {
+		bookmarked.push(id);
 	};
+
+	sessionStorage.setItem("book_marked", JSON.stringify(bookmarked));
+	return bookmarked;
+};
+
+const handleRemoveBookmark = (id) => {
+	const bookmarked = JSON.parse(sessionStorage.getItem("book_marked")) || [];
+
+	if (bookmarked.includes(id)) {
+		const index = bookmarked.indexOf(id);
+		bookmarked.splice(index, 1);
+	}
 	sessionStorage.setItem("book_marked", JSON.stringify(bookmarked));
 
 	return bookmarked;
 };
 
-const handleRemoveBookmark = (id) => {
-	const bookmarked = JSON.parse(sessionStorage.getItem("book_marked")) || {};
-	if (bookmarked[id]) {
-		delete bookmarked[id];
-		sessionStorage.setItem("book_marked", JSON.stringify(bookmarked));
-	}
-
-	return bookmarked;
-};
-
-const handlePlaceOnHold = ({ id, name, authors, bookType, quantity, number_of_physical_copies_available, is_ebook_available }) => {
+const handlePlaceOnHold = ({ id, bookTypeCheckout }) => {
 	// need to complete
 };
 


### PR DESCRIPTION
Some session storage keys cleanup!!

Using `books` key that stores all books description.

`cart`: stores book id as key and then some dates
`book_marked`: stores bookmarked books keys into an array
`my_library`: stores book id as key and some dates as value
`saved_authors`: an array stores author names